### PR TITLE
Change AurynTime to AurynDouble.

### DIFF
--- a/src/auryn_definitions.h
+++ b/src/auryn_definitions.h
@@ -249,7 +249,7 @@ unsigned short * auryn_vector_ushort_ptr (const auryn_vector_ushort * v, const N
 /*! Auryn spike event for binary monitors */
 struct spikeEvent_type
 {
-    AurynTime time;
+    AurynDouble time;
     NeuronID neuronID;
 };
 


### PR DESCRIPTION
Changes  spikeEvent_type time to floating point type.