### PR TITLE
Updated AdEx to use natural units.

### DIFF
--- a/src/AdExGroup.cpp
+++ b/src/AdExGroup.cpp
@@ -33,7 +33,7 @@ AdExGroup::AdExGroup(NeuronID size) : NeuronGroup(size)
 
 void AdExGroup::calculate_scale_constants()
 {
-    scale_mem  = dt/c_mem;
+    scale_mem  = dt/tau_mem;
     scale_w = dt/tau_w;
     scale_ampa = exp(-dt/tau_ampa);
     scale_gaba = exp(-dt/tau_gaba);
@@ -41,6 +41,7 @@ void AdExGroup::calculate_scale_constants()
 
 void AdExGroup::init()
 {
+    g_leak = 10e-9;
     e_rest = -70e-3;
     e_reset = -58e-3;
     e_rev_ampa = 0;
@@ -49,16 +50,15 @@ void AdExGroup::init()
     tau_ampa = 5e-3;
     tau_gaba = 10e-3;
     tau_w = 30e-3;
-    g_leak = 10e-9;
     c_mem = 200e-12;
+    tau_mem = c_mem/g_leak;
     deltat = 2e-3;
-    a = 2e-9;
-    b = 0;
+    a = 2e-9/g_leak;
+    b = 0./g_leak;
 
     w = get_state_vector("w");
 
     calculate_scale_constants();
-    
     bg_current = get_state_vector("bg_current");
 
     t_g_ampa = auryn_vector_float_ptr ( g_ampa , 0 );
@@ -98,13 +98,11 @@ void AdExGroup::evolve()
         t_w[i] += scale_w * (a * (t_mem[i]-e_rest) - t_w[i]);
 
         t_mem[i] += scale_mem * (
-                g_leak * (
-                  (e_rest-t_mem[i])
-                  + deltat * exp((t_mem[i]-e_thr)/deltat)
-                )
+                e_rest-t_mem[i]
+                + deltat * exp((t_mem[i]-e_thr)/deltat)
                 - t_g_ampa[i] * (t_mem[i]-e_rev_ampa)
                 - t_g_gaba[i] * (t_mem[i]-e_rev_gaba)
-                + (t_bg_cur[i]-t_w[i]));
+                + t_bg_cur[i]-t_w[i]);
 
 
         if (t_mem[i]>0.0) {
@@ -139,11 +137,12 @@ void AdExGroup::set_e_reset(AurynFloat ereset)
 {
     e_reset = ereset;
 }
+
 void AdExGroup::set_e_rest(AurynFloat erest)
 {
     e_rest = erest;
     for (NeuronID i = 0; i < get_rank_size(); i++)
-       auryn_vector_float_set (mem, i, e_rest);
+        auryn_vector_float_set (mem, i, e_rest);
 }
 
 void AdExGroup::set_a(AurynFloat _a)
@@ -217,4 +216,3 @@ AurynFloat AdExGroup::get_tau_gaba()
 {
     return tau_gaba;
 }
-

--- a/src/AdExGroup.cpp
+++ b/src/AdExGroup.cpp
@@ -138,6 +138,10 @@ void AdExGroup::set_e_reset(AurynFloat ereset)
     e_reset = ereset;
 }
 
+void AdExGroup::set_e_thr(AurynFloat ethr)
+{
+    e_thr = ethr;
+}
 void AdExGroup::set_e_rest(AurynFloat erest)
 {
     e_rest = erest;

--- a/src/AdExGroup.h
+++ b/src/AdExGroup.h
@@ -32,13 +32,13 @@
 
 
 /*! \brief Conductance based Adaptive Exponential neuron model - Brette and Gerstner (2005). Default values are taken from Table 1 (4a)  of Naud, Marcille, Clopath and Gerstner (2008)
- */
+*/
 class AdExGroup : public NeuronGroup
 {
 private:
     auryn_vector_float * bg_current;
     AurynFloat e_rest, e_reset, e_rev_gaba, e_rev_ampa,e_thr, g_leak, c_mem, deltat;
-    AurynFloat tau_ampa, tau_gaba;
+    AurynFloat tau_ampa, tau_gaba, tau_mem;
     AurynFloat scale_ampa, scale_gaba, scale_mem, scale_w;
     AurynFloat * t_w;
     AurynFloat a, tau_w, b;
@@ -57,24 +57,27 @@ private:
     inline void check_thresholds();
     virtual string get_output_line(NeuronID i);
     virtual void load_input_line(NeuronID i, const char * buf);
+
 public:
     /*! The default constructor of this NeuronGroup */
     AdExGroup(NeuronID size);
     virtual ~AdExGroup();
 
-    /*! Controls the constant current input to neuron i (default 500pA) */
+    /*! Controls the constant current input to neuron i in natural units of g_leak (default 500pA/10ns) */
     void set_bg_current(NeuronID i, AurynFloat current);
 
-    /*! Set value of slope factor delta_t (default 2mV) */
+    /*! Set value of slope factor deltat (default 2mV) */
     void set_delta_t(AurynFloat d);
-    /*! Set value of a (default 2nS) */
+    /*! Set value of a in natural units of g_leak (default 2nS/10ns) */
     void set_a(AurynFloat _a);
-    /*! Set value of b (default 0nS) */
+    /*! Set value of b in natural units of g_leak (default 0nS/10ns) */
     void set_b(AurynFloat _b);
     /*! Set value of V_r (default -70mV) */
     void set_e_reset(AurynFloat ereset);
     /*! Set value of E_l (default -70mV) */
     void set_e_rest(AurynFloat erest);
+    /*! Set value of V_t (default -50mV) */
+    void set_e_thr(AurynFloat ethr);
     /*! Sets the w time constant (default 30ms) */
     void set_tau_w(AurynFloat tauw);
     /*! Gets the current background current value for neuron i */


### PR DESCRIPTION
Minor changes to make the model use natural units instead of SI units. Makes the evolve method use less instructions and should now work nicely with conductances which are already in natural units of g_leak. 