### PR TITLE
Minor rate checker initialisation fix.

### DIFF
--- a/src/RateChecker.cpp
+++ b/src/RateChecker.cpp
@@ -56,7 +56,7 @@ bool RateChecker::propagate()
 {
 	state *= decay_multiplier;
 	state += 1.*src->get_spikes()->size()/timeconstant/size;
-	if ( state>popmin && state<popmax ) return true;
+	if ( state>=popmin && state=<popmax ) return true;
 	else  return false;
 }
 
@@ -72,5 +72,5 @@ AurynFloat RateChecker::get_rate()
 
 void RateChecker::reset()
 {
-	state = (popmax+popmin)/2;
+	state = popmin;
 }

--- a/src/RateChecker.cpp
+++ b/src/RateChecker.cpp
@@ -56,7 +56,7 @@ bool RateChecker::propagate()
 {
 	state *= decay_multiplier;
 	state += 1.*src->get_spikes()->size()/timeconstant/size;
-	if ( state>=popmin && state=<popmax ) return true;
+	if ( state>=popmin && state<=popmax ) return true;
 	else  return false;
 }
 


### PR DESCRIPTION
Changes the rate checker initialisation and logic just a bit. The current version initialises the rate checker to (popmax + popmin)/2 which is very misleading - I was under the impression that my simulation had some firing right from the beginning, when it didn't actually have any activity at all. 

The change initialises the checker to the minimum value