### PR TITLE
Added refractory period functionality to AdEx.

### DIFF
--- a/src/AdExGroup.cpp
+++ b/src/AdExGroup.cpp
@@ -1,25 +1,25 @@
-/* 
-* Copyright 2014-2015 Ankur Sinha and Friedemann Zenke 
+/*
+* Copyright 2014-2015 Ankur Sinha and Friedemann Zenke
 *
 * This file is part of Auryn, a simulation package for plastic
 * spiking neural networks.
-* 
+*
 * Auryn is free software: you can redistribute it and/or modify
 * it under the terms of the GNU General Public License as published by
 * the Free Software Foundation, either version 3 of the License, or
 * (at your option) any later version.
-* 
+*
 * Auryn is distributed in the hope that it will be useful,
 * but WITHOUT ANY WARRANTY; without even the implied warranty of
 * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 * GNU General Public License for more details.
-* 
+*
 * You should have received a copy of the GNU General Public License
 * along with Auryn.  If not, see <http://www.gnu.org/licenses/>.
 *
 * If you are using Auryn or parts of it for your work please cite:
-* Zenke, F. and Gerstner, W., 2014. Limits to high-speed simulations 
-* of spiking neural networks using general-purpose computers. 
+* Zenke, F. and Gerstner, W., 2014. Limits to high-speed simulations
+* of spiking neural networks using general-purpose computers.
 * Front Neuroinform 8, 76. doi: 10.3389/fninf.2014.00076
 */
 
@@ -56,9 +56,11 @@ void AdExGroup::init()
     a = 2e-9/g_leak;
     b = 0./g_leak;
 
+    set_refractory_period(0e-3);
     w = get_state_vector("w");
 
     calculate_scale_constants();
+    ref = auryn_vector_ushort_alloc (get_vector_size());
     bg_current = get_state_vector("bg_current");
 
     t_g_ampa = auryn_vector_float_ptr ( g_ampa , 0 );
@@ -66,6 +68,7 @@ void AdExGroup::init()
     t_bg_cur = auryn_vector_float_ptr ( bg_current , 0 );
     t_mem = auryn_vector_float_ptr ( mem , 0 );
     t_w = auryn_vector_float_ptr ( w , 0 );
+    t_ref = auryn_vector_ushort_ptr ( ref , 0 );
 
     clear();
 
@@ -77,6 +80,7 @@ void AdExGroup::clear()
     for (NeuronID i = 0; i < get_rank_size(); i++) {
        auryn_vector_float_set (mem, i, e_rest);
        auryn_vector_float_set (g_ampa, i, 0.);
+       auryn_vector_ushort_set (ref, i, 0);
        auryn_vector_float_set (g_gaba, i, 0.);
        auryn_vector_float_set (bg_current, i, 0.);
     }
@@ -85,30 +89,39 @@ void AdExGroup::clear()
 
 AdExGroup::~AdExGroup()
 {
+    if ( !evolve_locally() ) return;
+
+    auryn_vector_ushort_free (ref);
 }
 
 
 void AdExGroup::evolve()
 {
 
-	// TODO we should vectorize this code and use some fast SSE 
-	// library such as http://gruntthepeon.free.fr/ssemath/
-	// for the exponential
+    // TODO we should vectorize this code and use some fast SSE
+    // library such as http://gruntthepeon.free.fr/ssemath/
+    // for the exponential
     for (NeuronID i = 0 ; i < get_rank_size() ; ++i ) {
-        t_w[i] += scale_w * (a * (t_mem[i]-e_rest) - t_w[i]);
+        if (t_ref[i]==0) {
+            t_w[i] += scale_w * (a * (t_mem[i]-e_rest) - t_w[i]);
 
-        t_mem[i] += scale_mem * (
-                e_rest-t_mem[i]
-                + deltat * exp((t_mem[i]-e_thr)/deltat)
-                - t_g_ampa[i] * (t_mem[i]-e_rev_ampa)
-                - t_g_gaba[i] * (t_mem[i]-e_rev_gaba)
-                + t_bg_cur[i]-t_w[i]);
+            t_mem[i] += scale_mem * (
+                    e_rest-t_mem[i]
+                    + deltat * exp((t_mem[i]-e_thr)/deltat)
+                    - t_g_ampa[i] * (t_mem[i]-e_rev_ampa)
+                    - t_g_gaba[i] * (t_mem[i]-e_rev_gaba)
+                    + t_bg_cur[i]-t_w[i]);
 
 
-        if (t_mem[i]>0.0) {
-            push_spike(i);
-            t_mem[i] = e_reset;
-            t_w[i] += b;
+            if (t_mem[i]>0.0) {
+                push_spike(i);
+                t_mem[i] = e_reset;
+                t_w[i] += b;
+                t_ref[i] += refractory_time ;
+            }
+        } else {
+            t_ref[i]-- ;
+            t_mem[i] = e_rest ;
         }
     }
 
@@ -116,7 +129,7 @@ void AdExGroup::evolve()
     auryn_vector_float_scale(scale_gaba,g_gaba);
 }
 
-void AdExGroup::set_bg_current(NeuronID i, AurynFloat current) 
+void AdExGroup::set_bg_current(NeuronID i, AurynFloat current)
 {
     if ( localrank(i) )
         auryn_vector_float_set ( bg_current , global2rank(i) , current ) ;
@@ -176,14 +189,15 @@ void AdExGroup::set_c_mem(AurynFloat cm)
 AurynFloat AdExGroup::get_bg_current(NeuronID i) {
     if ( localrank(i) )
         return auryn_vector_float_get ( bg_current , global2rank(i) ) ;
-    else 
+    else
         return 0;
 }
 
 string AdExGroup::get_output_line(NeuronID i)
 {
     stringstream oss;
-    oss << get_mem(i) << " " << get_ampa(i) << " " << get_gaba(i) << " " 
+    oss << get_mem(i) << " " << get_ampa(i) << " " << get_gaba(i) << " "
+        << auryn_vector_ushort_get (ref, i) << " "
         << auryn_vector_float_get (bg_current, i) <<"\n";
     return oss.str();
 }
@@ -191,12 +205,14 @@ string AdExGroup::get_output_line(NeuronID i)
 void AdExGroup::load_input_line(NeuronID i, const char * buf)
 {
         float vmem,vampa,vgaba,vbgcur;
-        sscanf (buf,"%f %f %f %f",&vmem,&vampa,&vgaba,&vbgcur);
+        NeuronID vref;
+        sscanf (buf,"%f %f %f %u %f",&vmem,&vampa,&vgaba,&vref,&vbgcur);
         if ( localrank(i) ) {
             NeuronID trans = global2rank(i);
             set_mem(trans,vmem);
             set_ampa(trans,vampa);
             set_gaba(trans,vgaba);
+            auryn_vector_ushort_set (ref, trans, vref);
             auryn_vector_float_set (bg_current, trans, vbgcur);
         }
 }
@@ -221,4 +237,21 @@ void AdExGroup::set_tau_gaba(AurynFloat taum)
 AurynFloat AdExGroup::get_tau_gaba()
 {
     return tau_gaba;
+}
+
+void AdExGroup::set_refractory_period(AurynDouble t)
+{
+    refractory_time = (unsigned short) (t/dt);
+}
+
+void AdExGroup::virtual_serialize(boost::archive::binary_oarchive & ar, const unsigned int version )
+{
+    SpikingGroup::virtual_serialize(ar,version);
+    ar & *ref;
+}
+
+void AdExGroup::virtual_serialize(boost::archive::binary_iarchive & ar, const unsigned int version )
+{
+    SpikingGroup::virtual_serialize(ar,version);
+    ar & *ref;
 }

--- a/src/AdExGroup.h
+++ b/src/AdExGroup.h
@@ -1,25 +1,25 @@
-/* 
+/*
 * Copyright 2014-2015 Ankur Sinha and Friedemann Zenke
 *
 * This file is part of Auryn, a simulation package for plastic
 * spiking neural networks.
-* 
+*
 * Auryn is free software: you can redistribute it and/or modify
 * it under the terms of the GNU General Public License as published by
 * the Free Software Foundation, either version 3 of the License, or
 * (at your option) any later version.
-* 
+*
 * Auryn is distributed in the hope that it will be useful,
 * but WITHOUT ANY WARRANTY; without even the implied warranty of
 * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 * GNU General Public License for more details.
-* 
+*
 * You should have received a copy of the GNU General Public License
 * along with Auryn.  If not, see <http://www.gnu.org/licenses/>.
 *
 * If you are using Auryn or parts of it for your work please cite:
-* Zenke, F. and Gerstner, W., 2014. Limits to high-speed simulations 
-* of spiking neural networks using general-purpose computers. 
+* Zenke, F. and Gerstner, W., 2014. Limits to high-speed simulations
+* of spiking neural networks using general-purpose computers.
 * Front Neuroinform 8, 76. doi: 10.3389/fninf.2014.00076
 */
 
@@ -42,6 +42,8 @@ private:
     AurynFloat scale_ampa, scale_gaba, scale_mem, scale_w;
     AurynFloat * t_w;
     AurynFloat a, tau_w, b;
+    unsigned short refractory_time;
+    auryn_vector_ushort * ref;
 
     /*! Stores the adaptation current. */
     auryn_vector_float * w __attribute__((aligned(16)));
@@ -50,6 +52,7 @@ private:
     AurynFloat * t_g_gaba;
     AurynFloat * t_bg_cur;
     AurynFloat * t_mem;
+    unsigned short * t_ref;
 
     void init();
     void calculate_scale_constants();
@@ -58,6 +61,8 @@ private:
     virtual string get_output_line(NeuronID i);
     virtual void load_input_line(NeuronID i, const char * buf);
 
+	void virtual_serialize(boost::archive::binary_oarchive & ar, const unsigned int version );
+	void virtual_serialize(boost::archive::binary_iarchive & ar, const unsigned int version );
 public:
     /*! The default constructor of this NeuronGroup */
     AdExGroup(NeuronID size);
@@ -66,6 +71,8 @@ public:
     /*! Controls the constant current input to neuron i in natural units of g_leak (default 500pA/10ns) */
     void set_bg_current(NeuronID i, AurynFloat current);
 
+    /*! Setter for refractory time [s] */
+    void set_refractory_period(AurynDouble t);
     /*! Set value of slope factor deltat (default 2mV) */
     void set_delta_t(AurynFloat d);
     /*! Set value of a in natural units of g_leak (default 2nS/10ns) */


### PR DESCRIPTION
Even though AdEx has the capability to adapt, in cases where the input
current or excitatory conductance is very high, for example in case of
a network of excitatory neurons, the firing rates of the AdEx can be
very very high - which is not biologically plausible - since the
exponential term comes in to play too quickly. To remedy this, a
refractory period must be included.

I'm leaving the default refractory period as 0, which is closest to the
original model, but I've added the functionality required to set a
refractory period if users require it.

The following figures will show the differences.

Without a refractory period:
![adex-0ms-refractory](https://cloud.githubusercontent.com/assets/102575/9874574/c36508a2-5b9e-11e5-81d6-1df4ed56ea29.png)

With a 2ms refractory period:
![adex-2ms-refractory](https://cloud.githubusercontent.com/assets/102575/9874573/c3649552-5b9e-11e5-915d-5faa07839eea.png)

The F-I curve for AdEx without a refractory period - notice the very very high firing rates that the model is capable of in comparison to the TIF with a 2ms refractory period - clearly not biologically plausible. The upper limit here depends on the integration time step in use:
![adex-ab0-tif-fi](https://cloud.githubusercontent.com/assets/102575/9874595/eb565eba-5b9e-11e5-8a8c-03f8f3724219.png)
