### PR TITLE
small modification to AdEx model

### DIFF
--- a/src/auryn/AdExGroup.cpp
+++ b/src/auryn/AdExGroup.cpp
@@ -203,7 +203,7 @@ void AdExGroup::set_b(AurynFloat _b)
 
 void AdExGroup::set_delta_t(AurynFloat d)
 {
-    deltat = d/g_leak;
+    deltat = d;
 }
 
 void AdExGroup::set_g_leak(AurynFloat g)


### PR DESCRIPTION
DeltaT should not be divided by g_leak since the DeltaT is not scaled by g_leak. I.e., in the AdEx model, the exponential appears with prefactor g_leak*DeltaT, so there is no need to divide DeltaT by g_leak when the user sets it.
(This straightforward pull request is also to make sure I do these github things properly.) 