### PR TITLE
Update auryn_global.cpp for Boost 1.85.0

### DIFF
--- a/src/auryn/auryn_global.cpp
+++ b/src/auryn/auryn_global.cpp
@@ -51,7 +51,11 @@ namespace auryn {
 		// Init logger environment
 		try 
 		{ 
+#if BOOST_VERSION <= 108400
 			string log_prefix_ = boost::filesystem::basename(av[0]);
+#else
+			string log_prefix_ = boost::filesystem::path(av[0]).stem().string();
+#endif
 			log_prefix_.erase(std::remove(log_prefix_.begin(),log_prefix_.end(),' '),log_prefix_.end()); // remove spaces
 			std::transform(log_prefix_.begin(), log_prefix_.end(), log_prefix_.begin(), ::tolower); // convert to lower case
 


### PR DESCRIPTION
See https://www.boost.org/doc/libs/1_85_0/libs/filesystem/doc/release_history.html and https://www.boost.org/doc/libs/1_85_0/libs/filesystem/doc/deprecated.html